### PR TITLE
Added robotParamNode to gazebo_ros2_control plugin

### DIFF
--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -533,16 +533,7 @@ std::string GazeboRosControlPrivate::getURDF(std::string param_name) const
   while (urdf_string.empty()) {
     std::string search_param_name;
     RCLCPP_ERROR(rclcpp::get_logger("gazebo_ros2_control"), "param_name %s", param_name.c_str());
-
-    try {
-      auto f = parameters_client->get_parameters({param_name});
-      f.wait();
-      std::vector<rclcpp::Parameter> values = f.get();
-      urdf_string = values[0].as_string();
-    } catch (const std::exception & e) {
-      RCLCPP_ERROR(rclcpp::get_logger("gazebo_ros2_control"), "%s", e.what());
-    }
-
+    urdf_string = parameters_client->get_parameter<std::string>(param_name, "");
     if (!urdf_string.empty()) {
       break;
     } else {

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -502,12 +502,12 @@ std::string GazeboRosControlPrivate::getURDF(std::string param_name) const
     if (!rclcpp::ok()) {
       RCLCPP_ERROR(
         model_nh_->get_logger(), "Interrupted while waiting for %s service. Exiting.",
-        robot_description_node_);
+        robot_description_node_.c_str());
       return 0;
     }
     RCLCPP_ERROR(
       model_nh_->get_logger(), "%s service not available, waiting again...",
-      robot_description_node_);
+      robot_description_node_.c_str());
   }
 
   RCLCPP_ERROR(

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -82,6 +82,7 @@ public:
   // Strings
   std::string robot_namespace_;
   std::string robot_description_;
+  std::string robot_description_node_;
   std::string param_file_;
 
   // Transmissions in this plugin's scope
@@ -159,6 +160,13 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
     impl_->robot_description_ = impl_->sdf_->GetElement("robotParam")->Get<std::string>();
   } else {
     impl_->robot_description_ = "robot_description";  // default
+  }
+
+  // Get robot_description ROS param name
+  if (impl_->sdf_->HasElement("robotParamNode")) {
+    impl_->robot_description_node_ = impl_->sdf_->GetElement("robotParamNode")->Get<std::string>();
+  } else {
+    impl_->robot_description_node_ = "robot_state_publisher";  // default
   }
 
   // Get the robot simulation interface type
@@ -530,23 +538,24 @@ std::string GazeboRosControlPrivate::getURDF(std::string param_name) const
 
   using namespace std::chrono_literals;
   auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(
-    model_nh_,
-    "robot_state_publisher");
+    model_nh_, robot_description_node_);
   while (!parameters_client->wait_for_service(0.5s)) {
     if (!rclcpp::ok()) {
       RCLCPP_ERROR(
         rclcpp::get_logger(
-          "gazebo_ros2_control"), "Interrupted while waiting for the service. Exiting.");
+          "gazebo_ros2_control"), "Interrupted while waiting for %s service. Exiting.",
+        robot_description_node_);
       return 0;
     }
     RCLCPP_ERROR(
       rclcpp::get_logger(
-        "gazebo_ros2_control"), "service not available, waiting again...");
+        "gazebo_ros2_control"), "%s service not available, waiting again...",
+      robot_description_node_);
   }
 
   RCLCPP_ERROR(
     rclcpp::get_logger(
-      "gazebo_ros2_control"), "connected to service!! /robot_state_publisher");
+      "gazebo_ros2_control"), "connected to service!! %s", robot_description_node_);
 
   // search and wait for robot_description on param server
   while (urdf_string.empty()) {


### PR DESCRIPTION
Parameters in ROS 2 are associated to a node. By default the `robot_description` parameter will be requested to `/robot_state_pusblisher` but defining `robotParamNode` this node could be changed.

Signed-off-by: ahcorde <ahcorde@gmail.com>