### PR TITLE
Ahcorde/update/ros2 control

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,9 +28,9 @@ jobs:
         cd /home/ros2_ws/src/
         git clone https://github.com/ros-controls/ros2_control
         git clone https://github.com/ros-controls/ros2_controllers
-        git clone https://github.com/ddengster/ros2_control/ -b coffeebot_deps ros2_control_ddengster
-        touch ros2_control_ddengster/COLCON_IGNORE
-        cp -r ros2_control_ddengster/transmission_interface  ros2_control
+        # git clone https://github.com/ddengster/ros2_control/ -b coffeebot_deps ros2_control_ddengster
+        # touch ros2_control_ddengster/COLCON_IGNORE
+        # cp -r ros2_control_ddengster/transmission_interface  ros2_control
         rosdep update
         rosdep install --from-paths ./ -i -y --rosdistro foxy \
           --ignore-src

--- a/gazebo_ros2_control/include/gazebo_ros2_control/default_robot_hw_sim.hpp
+++ b/gazebo_ros2_control/include/gazebo_ros2_control/default_robot_hw_sim.hpp
@@ -88,15 +88,24 @@ private:
   rclcpp::Node::SharedPtr nh_;
 
 protected:
-  // Register the limits of the joint specified by joint_name and joint_handle. The limits are
-  // retrieved from joint_limit_nh. If urdf_model is not NULL, limits are retrieved from it also.
-  // Return the joint's type, lower position limit, upper position limit, and effort limit.
+  /// \brief Register the limits of the joint specified by joint_name and joint_handle.
+  /// The limits are retrieved from joint_limit_nh. If urdf_model is not NULL, limits are retrieved from
+  /// it also. Return the joint's type, lower position limit, upper position limit, and effort limit.
   void registerJointLimits(
     size_t joint_nr,
     const urdf::Model * const urdf_model,
     int * const joint_type, double * const lower_limit,
     double * const upper_limit, double * const effort_limit,
     double * const vel_limit);
+
+  /// \brief Refreshes all valid handle references in a collection.
+  /// Requests from the RobotHardware updated handle references. This is required after any call to
+  /// RobotHardware::register_joint() and before a handle is used or bound to a controller since the
+  /// internal implementation of register_joint binds to doubles inside a std::vector and thus growth of
+  /// that vector invalidates all existing iterators (i.e. handles).
+  /// See https://github.com/ros-controls/ros2_control/issues/212
+  /// If a handle in the collection is unset (no joint name or interface name) then it is skipped.
+  void bindJointHandles(std::vector<hardware_interface::JointHandle> & joint_iface_handles);
 
   unsigned int n_dof_;
   std::vector<std::string> joint_names_;

--- a/gazebo_ros2_control/include/gazebo_ros2_control/default_robot_hw_sim.hpp
+++ b/gazebo_ros2_control/include/gazebo_ros2_control/default_robot_hw_sim.hpp
@@ -89,8 +89,9 @@ private:
 
 protected:
   /// \brief Register the limits of the joint specified by joint_name and joint_handle.
-  /// The limits are retrieved from joint_limit_nh. If urdf_model is not NULL, limits are retrieved from
-  /// it also. Return the joint's type, lower position limit, upper position limit, and effort limit.
+  /// The limits are retrieved from joint_limit_nh. If urdf_model is not NULL, limits
+  /// are retrieved from it also. Return the joint's type, lower position limit, upper
+  /// position limit, and effort limit.
   void registerJointLimits(
     size_t joint_nr,
     const urdf::Model * const urdf_model,
@@ -99,10 +100,11 @@ protected:
     double * const vel_limit);
 
   /// \brief Refreshes all valid handle references in a collection.
-  /// Requests from the RobotHardware updated handle references. This is required after any call to
-  /// RobotHardware::register_joint() and before a handle is used or bound to a controller since the
-  /// internal implementation of register_joint binds to doubles inside a std::vector and thus growth of
-  /// that vector invalidates all existing iterators (i.e. handles).
+  /// Requests from the RobotHardware updated handle references. This is required after
+  /// any call to RobotHardware::register_joint() and before a handle is used or bound
+  /// to a controller since the internal implementation of register_joint binds to doubles
+  /// inside a std::vector and thus growth of that vector invalidates all existing
+  /// iterators (i.e. handles).
   /// See https://github.com/ros-controls/ros2_control/issues/212
   /// If a handle in the collection is unset (no joint name or interface name) then it is skipped.
   void bindJointHandles(std::vector<hardware_interface::JointHandle> & joint_iface_handles);

--- a/gazebo_ros2_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros2_control/src/default_robot_hw_sim.cpp
@@ -240,9 +240,9 @@ bool DefaultRobotHWSim::initSim(
     // set joints operation mode to ACTIVE and register handle for controlling opmode
     joint_opmodes_[j] = hardware_interface::OperationMode::ACTIVE;
     joint_opmodehandles_[j] = hardware_interface::OperationModeHandle(
-        joint_name, &joint_opmodes_[j]);
+      joint_name, &joint_opmodes_[j]);
     if (register_operation_mode_handle(&joint_opmodehandles_[j]) !=
-        hardware_interface::return_type::OK)
+      hardware_interface::return_type::OK)
     {
       RCLCPP_WARN_STREAM(nh_->get_logger(), "cant register opmode handle for joint" << joint_name);
     }
@@ -250,7 +250,8 @@ bool DefaultRobotHWSim::initSim(
 
   // since handles references may have changed due to underlying DynamicJointState msg
   // vectors resizing and reallocating we need to get these handles again
-  // any handles not registered are skipped, such as the command handles if they arent involved in the control method
+  // any handles not registered are skipped, such as the command handles if they arent
+  // involved in the control method
   bindJointHandles(joint_pos_stateh_);
   bindJointHandles(joint_vel_stateh_);
   bindJointHandles(joint_eff_stateh_);
@@ -262,7 +263,7 @@ bool DefaultRobotHWSim::initSim(
   //
   // Complete initialization of limits, PID controllers, etc now that registered handles are bound
   //
-  for(size_t j=0; j < joint_names_.size(); j++) {
+  for (size_t j = 0; j < joint_names_.size(); j++) {
     auto simjoint = sim_joints_[j];
     assert(simjoint);
 
@@ -311,7 +312,9 @@ bool DefaultRobotHWSim::initSim(
     if (register_operation_mode_handle(&joint_opmodehandles_[j]) !=
       hardware_interface::return_type::OK)
     {
-      RCLCPP_WARN_STREAM(nh_->get_logger(), "cant register opmode handle for joint" << joint_names_[j]);
+      RCLCPP_WARN_STREAM(
+        nh_->get_logger(),
+        "cant register opmode handle for joint" << joint_names_[j]);
     }
   }
 
@@ -595,31 +598,32 @@ void DefaultRobotHWSim::registerJointLimits(
   }
 }
 
-void DefaultRobotHWSim::bindJointHandles(std::vector<hardware_interface::JointHandle> & joint_iface_handles)
+void DefaultRobotHWSim::bindJointHandles(
+  std::vector<hardware_interface::JointHandle> & joint_iface_handles)
 {
-  for(auto& jh: joint_iface_handles)
-  {
+  for (auto & jh : joint_iface_handles) {
     // some handles, especially command handles, may not be registered so skip these
-    if(jh.get_name().empty() || jh.get_interface_name().empty())
+    if (jh.get_name().empty() || jh.get_interface_name().empty()) {
       continue;
+    }
 
     // now retrieve the handle with the bound value reference (bound directly to the
     // DynamicJointState msg in RobotHardware)
     if (get_joint_handle(jh) != hardware_interface::return_type::OK) {
       RCLCPP_ERROR_STREAM(
-          nh_->get_logger(), "state handle " << jh.get_interface_name() << " failure for joint " <<
-                                             jh.get_name());
+        nh_->get_logger(), "state handle " << jh.get_interface_name() << " failure for joint " <<
+          jh.get_name());
       continue;
     }
 
     // verify handle references a target value
     if (!jh) {
       RCLCPP_ERROR_STREAM(
-          nh_->get_logger(), jh.get_interface_name() << " handle for joint " << jh.get_name() <<
-                                                     " is null");
+        nh_->get_logger(), jh.get_interface_name() << " handle for joint " << jh.get_name() <<
+          " is null");
     }
   }
-};
+}
 }  // namespace gazebo_ros2_control
 
 PLUGINLIB_EXPORT_CLASS(gazebo_ros2_control::DefaultRobotHWSim, gazebo_ros2_control::RobotHWSim)

--- a/gazebo_ros2_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros2_control/src/default_robot_hw_sim.cpp
@@ -95,45 +95,45 @@ bool DefaultRobotHWSim::initSim(
     //
 
     // Check that this transmission has one joint
-    if (transmissions[j].joints_.empty()) {
+    if (transmissions[j].joints.empty()) {
       RCLCPP_WARN_STREAM(
-        nh_->get_logger(), "Transmission " << transmissions[j].name_ <<
+        nh_->get_logger(), "Transmission " << transmissions[j].name <<
           " has no associated joints.");
       continue;
-    } else if (transmissions[j].joints_.size() > 1) {
+    } else if (transmissions[j].joints.size() > 1) {
       RCLCPP_WARN_STREAM(
-        nh_->get_logger(), "Transmission " << transmissions[j].name_ <<
+        nh_->get_logger(), "Transmission " << transmissions[j].name <<
           " has more than one joint. Currently the default robot hardware simulation " <<
           " interface only supports one.");
       continue;
     }
 
-    std::string joint_name = joint_names_[j] = transmissions[j].joints_[0].name_;
+    std::string joint_name = joint_names_[j] = transmissions[j].joints[0].name;
 
-    std::vector<std::string> joint_interfaces = transmissions[j].joints_[0].hardware_interfaces_;
+    std::vector<std::string> joint_interfaces = transmissions[j].joints[0].interfaces;
     if (joint_interfaces.empty() &&
-      !(transmissions[j].actuators_.empty()) &&
-      !(transmissions[j].actuators_[0].hardware_interfaces_.empty()))
+      !(transmissions[j].actuators.empty()) &&
+      !(transmissions[j].actuators[0].interfaces.empty()))
     {
       // TODO(anyone): Deprecate HW interface specification in actuators in ROS J
-      joint_interfaces = transmissions[j].actuators_[0].hardware_interfaces_;
+      joint_interfaces = transmissions[j].actuators[0].interfaces;
       RCLCPP_WARN_STREAM(
         nh_->get_logger(), "The <hardware_interface> element of transmission " <<
-          transmissions[j].name_ << " should be nested inside the <joint> element," <<
+          transmissions[j].name << " should be nested inside the <joint> element," <<
           " not <actuator>. The transmission will be properly loaded, but please update " <<
           "your robot model to remain compatible with future versions of the plugin.");
     }
     if (joint_interfaces.empty()) {
       RCLCPP_WARN_STREAM(
-        nh_->get_logger(), "Joint " << transmissions[j].name_ <<
-          " of transmission " << transmissions[j].name_ <<
+        nh_->get_logger(), "Joint " << transmissions[j].name <<
+          " of transmission " << transmissions[j].name <<
           " does not specify any hardware interface. " <<
           "Not adding it to the robot hardware simulation.");
       continue;
     } else if (joint_interfaces.size() > 1) {
       RCLCPP_WARN_STREAM(
-        nh_->get_logger(), "Joint " << transmissions[j].name_ <<
-          " of transmission " << transmissions[j].name_ <<
+        nh_->get_logger(), "Joint " << transmissions[j].name <<
+          " of transmission " << transmissions[j].name <<
           " specifies multiple hardware interfaces. " <<
           "Currently the default robot hardware simulation interface only supports one." <<
           "Using the first entry");
@@ -259,13 +259,13 @@ bool DefaultRobotHWSim::initSim(
               joint_control_methods_[j] = POSITION_PID;
               RCLCPP_INFO(
                 nh_->get_logger(), "joint %s is configured in POSITION_PID mode",
-                transmissions[j].joints_[0].name_.c_str());
+                transmissions[j].joints[0].name.c_str());
               break;
             case VELOCITY:
               joint_control_methods_[j] = VELOCITY_PID;
               RCLCPP_INFO(
                 nh_->get_logger(), "joint %s is configured in VELOCITY_PID mode",
-                transmissions[j].joints_[0].name_.c_str());
+                transmissions[j].joints[0].name.c_str());
               break;
           }
         }
@@ -278,11 +278,11 @@ bool DefaultRobotHWSim::initSim(
     // set joints operation mode to ACTIVE and register handle for controlling opmode
     joint_opmodes_[j] = hardware_interface::OperationMode::ACTIVE;
     joint_opmodehandles_[j] = hardware_interface::OperationModeHandle(
-      joint_name, &joint_opmodes_[j]);
+      joint_names_[j], &joint_opmodes_[j]);
     if (register_operation_mode_handle(&joint_opmodehandles_[j]) !=
       hardware_interface::return_type::OK)
     {
-      RCLCPP_WARN_STREAM(nh_->get_logger(), "cant register opmode handle for joint" << joint_name);
+      RCLCPP_WARN_STREAM(nh_->get_logger(), "cant register opmode handle for joint" << joint_names_[j]);
     }
   }
 

--- a/gazebo_ros2_control/src/default_robot_hw_sim.cpp
+++ b/gazebo_ros2_control/src/default_robot_hw_sim.cpp
@@ -245,14 +245,14 @@ bool DefaultRobotHWSim::initSim(
       &joint_effort_limits_[j], &joint_vel_limits_[j]);
     if (joint_control_methods_[j] != EFFORT) {
       try {
+        nh_->declare_parameter(transmissions[j].joints[0].name + ".p", 25.0);
+        nh_->declare_parameter(transmissions[j].joints[0].name + ".i", 10.0);
+        nh_->declare_parameter(transmissions[j].joints[0].name + ".d", 5.0);
+        nh_->declare_parameter(transmissions[j].joints[0].name + ".i_clamp_max", 3.0);
+        nh_->declare_parameter(transmissions[j].joints[0].name + ".i_clamp_min", 3.0);
+        nh_->declare_parameter(transmissions[j].joints[0].name + ".antiwindup", false);
         pid_controllers_.push_back(
-          control_toolbox::PidROS(nh_, transmissions[j].joints_[0].name_));
-        nh_->declare_parameter(transmissions[j].joints_[0].name_ + ".p");
-        nh_->declare_parameter(transmissions[j].joints_[0].name_ + ".i");
-        nh_->declare_parameter(transmissions[j].joints_[0].name_ + ".d");
-        nh_->declare_parameter(transmissions[j].joints_[0].name_ + ".i_clamp_max");
-        nh_->declare_parameter(transmissions[j].joints_[0].name_ + ".i_clamp_min");
-        nh_->declare_parameter(transmissions[j].joints_[0].name_ + ".antiwindup");
+          control_toolbox::PidROS(nh_, transmissions[j].joints[0].name));
         if (pid_controllers_[j].initPid()) {
           switch (joint_control_methods_[j]) {
             case POSITION:

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -237,7 +237,7 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
   try {
     urdf_string = impl_->getURDF(impl_->robot_description_);
     impl_->transmissions_ = transmission_interface::parse_transmissions_from_urdf(urdf_string);
-  } catch(const std::runtime_error& ex) {
+  } catch (const std::runtime_error & ex) {
     RCLCPP_ERROR_STREAM(
       impl_->model_nh_->get_logger(),
       "Error parsing URDF in gazebo_ros2_control plugin, plugin not active : " << ex.what());

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -60,9 +60,6 @@ public:
   // Get the URDF XML from the parameter server
   std::string getURDF(std::string param_name) const;
 
-  // Get Transmissions from the URDF
-  bool parseTransmissionsFromURDF(const std::string & urdf_string);
-
   void eStopCB(const std::shared_ptr<std_msgs::msg::Bool> e_stop_active);
 
   // Node Handles
@@ -236,11 +233,14 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
   // Read urdf from ros parameter server then
   // setup actuators and mechanism control node.
   // This call will block if ROS is not properly initialized.
-  const std::string urdf_string = impl_->getURDF(impl_->robot_description_);
-  if (!impl_->parseTransmissionsFromURDF(urdf_string)) {
-    RCLCPP_ERROR(
+  std::string urdf_string;
+  try {
+    urdf_string = impl_->getURDF(impl_->robot_description_);
+    impl_->transmissions_ = transmission_interface::parse_transmissions_from_urdf(urdf_string);
+  } catch(const std::runtime_error& ex) {
+    RCLCPP_ERROR_STREAM(
       impl_->model_nh_->get_logger(),
-      "Error parsing URDF in gazebo_ros2_control plugin, plugin not active.\n");
+      "Error parsing URDF in gazebo_ros2_control plugin, plugin not active : " << ex.what());
     return;
   }
 
@@ -545,13 +545,6 @@ std::string GazeboRosControlPrivate::getURDF(std::string param_name) const
     model_nh_->get_logger(), "Recieved urdf from param server, parsing...");
 
   return urdf_string;
-}
-
-// Get Transmissions from the URDF
-bool GazeboRosControlPrivate::parseTransmissionsFromURDF(const std::string & urdf_string)
-{
-  transmission_interface::TransmissionParser::parse(urdf_string, transmissions_);
-  return true;
 }
 
 // Emergency stop callback


### PR DESCRIPTION
In a nutshell:
* fix errors due to names of members in the TransmissionInfo, ActuatorInfo, etc., interfaces were renamed in ros2_controls recent PR to be consistent with ros2_controls naming convention.
* moved declaration of PID parameters to precede the call to the PidROS constructor. PidROS looks for these parameters during construction and was causing SEGVs sometimes. In my debugger it seemed like the construction of the contained ParameterService was causing "parameter changed" events to fire and this was the source of the SEGVs. Also, the declaration of parameters didnt have defaults so log was complaining about parameters not being of floating type.
* To fix the issue of invalid handles, I split the joint loop in initSim into two. First registering handles, only then are handles retrieved and limits and PID can continue initializing.
* removed the GazeboRosControlPrivate parseTransmissionsFromURDF method. It was a 1 line call to the transmission parser and regardless of parsing it returned true so didnt handle errors. plugin Load now calls parser directly and catches errors.