### PR TITLE
Expose include path inside INCLUDE_DIRS

### DIFF
--- a/gazebo_ros2_control/CMakeLists.txt
+++ b/gazebo_ros2_control/CMakeLists.txt
@@ -60,6 +60,10 @@ install(TARGETS
   RUNTIME DESTINATION bin
 )
 
+ament_export_include_directories(
+  include
+)
+
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(rclcpp)
 ament_export_libraries(


### PR DESCRIPTION
Signed-off-by: Chen Bainian <chenbn@artc.a-star.edu.sg>

Include directories cannot be linked through `ament_target_dependencies()` due to the `include` path is not inside `gazebo_ros2_control_INCLUDE_DIRS`.

This small change will fix it.
