### PR TITLE
Load controllers in the example launch files

### DIFF
--- a/gazebo_ros2_control_demos/launch/cart_example_effort.launch.py
+++ b/gazebo_ros2_control_demos/launch/cart_example_effort.launch.py
@@ -18,7 +18,8 @@ from ament_index_python.packages import get_package_share_directory
 
 
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription
+from launch.actions import ExecuteProcess, IncludeLaunchDescription, RegisterEventHandler
+from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 from launch_ros.actions import Node
@@ -55,7 +56,29 @@ def generate_launch_description():
                                    '-entity', 'cartpole'],
                         output='screen')
 
+    load_joint_state_controller = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_start_controller', 'joint_state_controller'],
+        output='screen'
+    )
+
+    load_effort_controller = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_start_controller', 'effort_controllers'],
+        output='screen'
+    )
+
     return LaunchDescription([
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=spawn_entity,
+                on_exit=[load_joint_state_controller],
+            )
+        ),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=load_joint_state_controller,
+                on_exit=[load_effort_controller],
+            )
+        ),
         gazebo,
         node_robot_state_publisher,
         spawn_entity,

--- a/gazebo_ros2_control_demos/launch/cart_example_position.launch.py
+++ b/gazebo_ros2_control_demos/launch/cart_example_position.launch.py
@@ -18,7 +18,8 @@ from ament_index_python.packages import get_package_share_directory
 
 
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription
+from launch.actions import ExecuteProcess, IncludeLaunchDescription, RegisterEventHandler
+from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 from launch_ros.actions import Node
@@ -55,7 +56,29 @@ def generate_launch_description():
                                    '-entity', 'cartpole'],
                         output='screen')
 
+    load_joint_state_controller = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_start_controller', 'joint_state_controller'],
+        output='screen'
+    )
+
+    load_joint_trajectory_controller = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_start_controller', 'joint_trajectory_controller'],
+        output='screen'
+    )
+
     return LaunchDescription([
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=spawn_entity,
+                on_exit=[load_joint_state_controller],
+            )
+        ),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=load_joint_state_controller,
+                on_exit=[load_joint_trajectory_controller],
+            )
+        ),
         gazebo,
         node_robot_state_publisher,
         spawn_entity,

--- a/gazebo_ros2_control_demos/launch/cart_example_velocity.launch.py
+++ b/gazebo_ros2_control_demos/launch/cart_example_velocity.launch.py
@@ -18,7 +18,8 @@ from ament_index_python.packages import get_package_share_directory
 
 
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription
+from launch.actions import ExecuteProcess, IncludeLaunchDescription, RegisterEventHandler
+from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 from launch_ros.actions import Node
@@ -54,7 +55,29 @@ def generate_launch_description():
                                    '-entity', 'cartpole'],
                         output='screen')
 
+    load_joint_state_controller = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_start_controller', 'joint_state_controller'],
+        output='screen'
+    )
+
+    load_velocity_controller = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_start_controller', 'velocity_controller'],
+        output='screen'
+    )
+
     return LaunchDescription([
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=spawn_entity,
+                on_exit=[load_joint_state_controller],
+            )
+        ),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=load_joint_state_controller,
+                on_exit=[load_velocity_controller],
+            )
+        ),
         gazebo,
         node_robot_state_publisher,
         spawn_entity,


### PR DESCRIPTION
I used `ros2control` to load the controllers as @Karsten1987 described in this comment https://github.com/ros-simulation/gazebo_ros2_control/pull/60#issuecomment-780732126

This PR builds on top of your PR @Karsten1987, do you mind to have a look ?

Signed-off-by: ahcorde <ahcorde@gmail.com>