### PR TITLE
Add Imu and FT state interfaces

### DIFF
--- a/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system.hpp
+++ b/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system.hpp
@@ -67,6 +67,9 @@ public:
     sdf::ElementPtr sdf) override;
 
 private:
+  void registerSensors(
+    const hardware_interface::HardwareInfo & hardware_info,
+    gazebo::physics::ModelPtr parent_model);
   /// \brief Private data class
   std::unique_ptr<GazeboSystemPrivate> dataPtr;
 };

--- a/gazebo_ros2_control/src/gazebo_system.cpp
+++ b/gazebo_ros2_control/src/gazebo_system.cpp
@@ -87,8 +87,17 @@ public:
   /// \brief An array per IMU with 4 orientation, 3 angular velocity and 3 linear acceleration
   std::vector<std::array<double, 10>> imu_sensor_data_;
 
-  /// \brief The current effort forces applied to the joints
+  /// \brief The ROS2 Control state interface for the current imu readings
   std::vector<std::shared_ptr<hardware_interface::StateInterface>> imu_state_;
+
+  /// \brief handles to the FT sensors from within Gazebo
+  std::vector<gazebo::sensors::ForceTorqueSensorPtr> sim_ft_sensors_;
+
+  /// \brief An array per FT sensor for 3D force and torquee
+  std::vector<std::array<double, 6>> ft_sensor_data_;
+
+  /// \brief The ROS2 Control state interface for the current FT sensor readings
+  std::vector<std::shared_ptr<hardware_interface::StateInterface>> ft_sensor_state_;
 };
 
 namespace gazebo_ros2_control
@@ -208,10 +217,32 @@ void GazeboSystem::registerSensors(
   // Collect gazebo sensor handles
   size_t n_sensors = hardware_info.sensors.size();
   std::vector<hardware_interface::ComponentInfo> imu_components_;
+  std::vector<hardware_interface::ComponentInfo> ft_sensor_components_;
+
+  // This is split in two steps: Count the number and type of sensor and associate the interfaces
+  // So we have resize only once the structures where the data will be stored, and we can safely
+  // use pointers to the structures
   for (unsigned int j = 0; j < n_sensors; j++) {
     hardware_interface::ComponentInfo component = hardware_info.sensors[j];
     std::string sensor_name = component.name;
-    std::vector<std::string> gz_sensor_names = parent_model->SensorScopedName(sensor_name);
+
+    // This can't be used, because it only looks for sensor in links, but force_torque_sensor
+    // must be in a joint, as in not found by SensorScopedName
+    // std::vector<std::string> gz_sensor_names = parent_model->SensorScopedName(sensor_name);
+
+    // Workaround to find sensors whose parent is a link or joint of parent_model
+    std::vector<std::string> gz_sensor_names;
+    for (const auto & s : gazebo::sensors::SensorManager::Instance()->GetSensors()) {
+      const std::string sensor_parent = s->ParentName();
+      if (s->Name() != sensor_name) {
+        continue;
+      }
+      if ((parent_model->GetJoint(sensor_parent) != nullptr) ||
+        parent_model->GetLink(sensor_parent) != nullptr)
+      {
+        gz_sensor_names.push_back(s->ScopedName());
+      }
+    }
     if (gz_sensor_names.empty()) {
       RCLCPP_WARN_STREAM(
         this->nh_->get_logger(), "Skipping sensor in the URDF named '" << sensor_name <<
@@ -244,13 +275,22 @@ void GazeboSystem::registerSensors(
       }
       imu_components_.push_back(component);
       this->dataPtr->sim_imu_sensors_.push_back(imu_sensor);
+    } else if (simsensor->Type() == "force_torque") {
+      gazebo::sensors::ForceTorqueSensorPtr ft_sensor =
+        std::dynamic_pointer_cast<gazebo::sensors::ForceTorqueSensor>(simsensor);
+      if (!ft_sensor) {
+        RCLCPP_ERROR_STREAM(
+          this->nh_->get_logger(),
+          "Error retrieving casting sensor '" << sensor_name << " to ForceTorqueSensor");
+        continue;
+      }
+      ft_sensor_components_.push_back(component);
+      this->dataPtr->sim_ft_sensors_.push_back(ft_sensor);
     }
   }
 
-  // This is split in two steps: Count the number and type of sensor and associate the interfaces
-  // So we have resize only once the structures where the data will be stored, and we can safely
-  // use pointers to the structures
   this->dataPtr->imu_sensor_data_.resize(this->dataPtr->sim_imu_sensors_.size());
+  this->dataPtr->ft_sensor_data_.resize(this->dataPtr->sim_ft_sensors_.size());
 
   for (unsigned int i = 0; i < imu_components_.size(); i++) {
     const std::string & sensor_name = imu_components_[i].name;
@@ -276,6 +316,28 @@ void GazeboSystem::registerSensors(
       this->dataPtr->imu_state_.emplace_back(
         std::make_shared<hardware_interface::StateInterface>(
           sensor_name, state_interface.name, &this->dataPtr->imu_sensor_data_[i][data_index]));
+    }
+  }
+  for (unsigned int i = 0; i < ft_sensor_components_.size(); i++) {
+    const std::string & sensor_name = ft_sensor_components_[i].name;
+    RCLCPP_INFO_STREAM(this->nh_->get_logger(), "Loading sensor: " << sensor_name);
+    RCLCPP_INFO_STREAM(
+      this->nh_->get_logger(), "\tState:");
+    for (const auto & state_interface : ft_sensor_components_[i].state_interfaces) {
+      static const std::map<std::string, size_t> interface_name_map = {
+        {"force.x", 0},
+        {"force.y", 1},
+        {"force.z", 2},
+        {"torque.x", 3},
+        {"torque.y", 4},
+        {"torque.z", 5}
+      };
+      RCLCPP_INFO_STREAM(this->nh_->get_logger(), "\t\t " << state_interface.name);
+
+      size_t data_index = interface_name_map.at(state_interface.name);
+      this->dataPtr->ft_sensor_state_.emplace_back(
+        std::make_shared<hardware_interface::StateInterface>(
+          sensor_name, state_interface.name, &this->dataPtr->ft_sensor_data_[i][data_index]));
     }
   }
 }
@@ -323,6 +385,9 @@ GazeboSystem::export_state_interfaces()
   }
   for (unsigned int i = 0; i < this->dataPtr->imu_state_.size(); i++) {
     state_interfaces.emplace_back(*this->dataPtr->imu_state_[i]);
+  }
+  for (unsigned int i = 0; i < this->dataPtr->ft_sensor_state_.size(); i++) {
+    state_interfaces.emplace_back(*this->dataPtr->ft_sensor_state_[i]);
   }
   return state_interfaces;
 }
@@ -398,6 +463,17 @@ hardware_interface::return_type GazeboSystem::read()
     this->dataPtr->imu_sensor_data_[j][7] = sim_imu->LinearAcceleration().X();
     this->dataPtr->imu_sensor_data_[j][8] = sim_imu->LinearAcceleration().Y();
     this->dataPtr->imu_sensor_data_[j][9] = sim_imu->LinearAcceleration().Z();
+  }
+
+  for (unsigned int j = 0; j < this->dataPtr->sim_ft_sensors_.size(); j++) {
+    auto sim_ft_sensor = this->dataPtr->sim_ft_sensors_[j];
+    this->dataPtr->imu_sensor_data_[j][0] = sim_ft_sensor->Force().X();
+    this->dataPtr->imu_sensor_data_[j][1] = sim_ft_sensor->Force().Y();
+    this->dataPtr->imu_sensor_data_[j][2] = sim_ft_sensor->Force().Z();
+
+    this->dataPtr->imu_sensor_data_[j][3] = sim_ft_sensor->Torque().X();
+    this->dataPtr->imu_sensor_data_[j][4] = sim_ft_sensor->Torque().Y();
+    this->dataPtr->imu_sensor_data_[j][5] = sim_ft_sensor->Torque().Z();
   }
   return hardware_interface::return_type::OK;
 }

--- a/gazebo_ros2_control_demos/config/cartpole_controller_velocity.yaml
+++ b/gazebo_ros2_control_demos/config/cartpole_controller_velocity.yaml
@@ -8,6 +8,9 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
+    imu_sensor_broadcaster:
+      type: imu_sensor_broadcaster/IMUSensorBroadcaster
+
 velocity_controller:
   ros__parameters:
     joints:
@@ -17,3 +20,7 @@ velocity_controller:
     state_interfaces:
       - position
       - velocity
+imu_sensor_broadcaster:
+  ros__parameters:
+    sensor_name: cart_imu_sensor
+    frame_id: imu

--- a/gazebo_ros2_control_demos/launch/cart_example_velocity.launch.py
+++ b/gazebo_ros2_control_demos/launch/cart_example_velocity.launch.py
@@ -66,6 +66,11 @@ def generate_launch_description():
         output='screen'
     )
 
+    load_imu_sensor_broadcaster = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_start_controller', 'imu_sensor_broadcaster'],
+        output='screen'
+    )
+
     return LaunchDescription([
         RegisterEventHandler(
             event_handler=OnProcessExit(
@@ -77,6 +82,12 @@ def generate_launch_description():
             event_handler=OnProcessExit(
                 target_action=load_joint_state_controller,
                 on_exit=[load_joint_trajectory_controller],
+            )
+        ),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=load_joint_trajectory_controller,
+                on_exit=[load_imu_sensor_broadcaster],
             )
         ),
         gazebo,

--- a/gazebo_ros2_control_demos/urdf/test_cart_position.xacro.urdf
+++ b/gazebo_ros2_control_demos/urdf/test_cart_position.xacro.urdf
@@ -48,35 +48,6 @@
     <limit effort="1000.0" lower="-15" upper="15" velocity="30"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
-  <link name="imu">
-    <inertial>
-      <mass value="0.1"/>
-      <inertia ixx="1.0" ixy="0" ixz="0" iyy="1.0" iyz="0" izz="1.0"/>
-    </inertial>
-    <!-- <visual>
-      <origin xyz="0 0 0"/>
-      <geometry>
-        <box size="0.1 0.1 0.1"/>
-      </geometry>
-      <material name="red">
-        <color rgba="0.8 0 0 1"/>
-      </material>
-    </visual> -->
-  </link>
-  <joint name="cart_to_imu" type="fixed">
-    <origin xyz="0.0 0.0 0.0"/>
-    <parent link="cart"/>
-    <child link="imu"/>
-    <dynamics damping="0.0" friction="0.0"/>
-  </joint>
-
-  <gazebo reference="imu">
-    <sensor name="cart_imu_sensor" type="imu">
-      <always_on>1</always_on>
-      <update_rate>10.0</update_rate>
-    </sensor>
-  </gazebo>
-
   <ros2_control name="GazeboSystem" type="system">
     <hardware>
       <plugin>gazebo_ros2_control/GazeboSystem</plugin>
@@ -90,18 +61,6 @@
       <state_interface name="velocity"/>
       <state_interface name="effort"/>
     </joint>
-    <sensor name="cart_imu_sensor">
-      <state_interface name="orientation.x"/>
-      <state_interface name="orientation.y"/>
-      <state_interface name="orientation.z"/>
-      <state_interface name="orientation.w"/>
-      <state_interface name="angular_velocity.x"/>
-      <state_interface name="angular_velocity.y"/>
-      <state_interface name="angular_velocity.z"/>
-      <state_interface name="linear_acceleration.x"/>
-      <state_interface name="linear_acceleration.y"/>
-      <state_interface name="linear_acceleration.z"/>
-    </sensor>
   </ros2_control>
 
   <gazebo>

--- a/gazebo_ros2_control_demos/urdf/test_cart_position.xacro.urdf
+++ b/gazebo_ros2_control_demos/urdf/test_cart_position.xacro.urdf
@@ -48,6 +48,34 @@
     <limit effort="1000.0" lower="-15" upper="15" velocity="30"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
+  <link name="imu">
+    <inertial>
+      <mass value="0.1"/>
+      <inertia ixx="1.0" ixy="0" ixz="0" iyy="1.0" iyz="0" izz="1.0"/>
+    </inertial>
+    <!-- <visual>
+      <origin xyz="0 0 0"/>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+      <material name="red">
+        <color rgba="0.8 0 0 1"/>
+      </material>
+    </visual> -->
+  </link>
+  <joint name="cart_to_imu" type="fixed">
+    <origin xyz="0.0 0.0 0.0"/>
+    <parent link="cart"/>
+    <child link="imu"/>
+    <dynamics damping="0.0" friction="0.0"/>
+  </joint>
+
+  <gazebo reference="imu">
+    <sensor name="cart_imu_sensor" type="imu">
+      <always_on>1</always_on>
+      <update_rate>10.0</update_rate>
+    </sensor>
+  </gazebo>
 
   <ros2_control name="GazeboSystem" type="system">
     <hardware>
@@ -62,6 +90,18 @@
       <state_interface name="velocity"/>
       <state_interface name="effort"/>
     </joint>
+    <sensor name="cart_imu_sensor">
+      <state_interface name="orientation.x"/>
+      <state_interface name="orientation.y"/>
+      <state_interface name="orientation.z"/>
+      <state_interface name="orientation.w"/>
+      <state_interface name="angular_velocity.x"/>
+      <state_interface name="angular_velocity.y"/>
+      <state_interface name="angular_velocity.z"/>
+      <state_interface name="linear_acceleration.x"/>
+      <state_interface name="linear_acceleration.y"/>
+      <state_interface name="linear_acceleration.z"/>
+    </sensor>
   </ros2_control>
 
   <gazebo>

--- a/gazebo_ros2_control_demos/urdf/test_cart_velocity.xacro.urdf
+++ b/gazebo_ros2_control_demos/urdf/test_cart_velocity.xacro.urdf
@@ -53,15 +53,6 @@
       <mass value="0.1"/>
       <inertia ixx="1.0" ixy="0" ixz="0" iyy="1.0" iyz="0" izz="1.0"/>
     </inertial>
-    <!-- <visual>
-      <origin xyz="0 0 0"/>
-      <geometry>
-        <box size="0.1 0.1 0.1"/>
-      </geometry>
-      <material name="red">
-        <color rgba="0.8 0 0 1"/>
-      </material>
-    </visual> -->
   </link>
   <joint name="cart_to_imu" type="fixed">
     <origin xyz="0.0 0.0 0.0"/>

--- a/gazebo_ros2_control_demos/urdf/test_cart_velocity.xacro.urdf
+++ b/gazebo_ros2_control_demos/urdf/test_cart_velocity.xacro.urdf
@@ -48,6 +48,35 @@
     <limit effort="1000.0" lower="-15" upper="15" velocity="30"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
+  <link name="imu">
+    <inertial>
+      <mass value="0.1"/>
+      <inertia ixx="1.0" ixy="0" ixz="0" iyy="1.0" iyz="0" izz="1.0"/>
+    </inertial>
+    <!-- <visual>
+      <origin xyz="0 0 0"/>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+      <material name="red">
+        <color rgba="0.8 0 0 1"/>
+      </material>
+    </visual> -->
+  </link>
+  <joint name="cart_to_imu" type="fixed">
+    <origin xyz="0.0 0.0 0.0"/>
+    <parent link="cart"/>
+    <child link="imu"/>
+    <dynamics damping="0.0" friction="0.0"/>
+  </joint>
+
+  <gazebo reference="imu">
+    <sensor name="cart_imu_sensor" type="imu">
+      <always_on>1</always_on>
+      <update_rate>10.0</update_rate>
+    </sensor>
+  </gazebo>
+
   <ros2_control name="GazeboSystem" type="system">
     <hardware>
       <plugin>gazebo_ros2_control/GazeboSystem</plugin>
@@ -61,7 +90,20 @@
       <state_interface name="velocity"/>
       <state_interface name="effort"/>
     </joint>
+    <sensor name="cart_imu_sensor">
+      <state_interface name="orientation.x"/>
+      <state_interface name="orientation.y"/>
+      <state_interface name="orientation.z"/>
+      <state_interface name="orientation.w"/>
+      <state_interface name="angular_velocity.x"/>
+      <state_interface name="angular_velocity.y"/>
+      <state_interface name="angular_velocity.z"/>
+      <state_interface name="linear_acceleration.x"/>
+      <state_interface name="linear_acceleration.y"/>
+      <state_interface name="linear_acceleration.z"/>
+    </sensor>
   </ros2_control>
+
   <gazebo>
     <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
       <parameters>$(find gazebo_ros2_control_demos)/config/cartpole_controller_velocity.yaml</parameters>


### PR DESCRIPTION
Add state interfaces for gazebo sensors.

This allows sensors from being read directly from ROS control without going through ROS topics, which can better replicate real hardware where the sensor is read through the same bus as the actuators.

I took the liberty of establishing some standard interface names for IMU: "orientation.x", "linear_acceleration.x" and "angular_velocity.x". And obviously for y, z and w in the case of the orientation quaternion.

Maybe we could put this somewhere more standard , thoughts @bmagyar?

If this looks good, I'll do the same for the FT Sensor. 
We've been using this for years in ROS1 in https://github.com/pal-robotics/pal_hardware_gazebo/blob/melodic-devel/src/pal_hardware_gazebo.cpp but we think it will benefit more people here in ROS2.