### PR TITLE
Adding ros2_control dependency to demos (#74)

### DIFF
--- a/gazebo_ros2_control_demos/package.xml
+++ b/gazebo_ros2_control_demos/package.xml
@@ -32,6 +32,7 @@
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>ros2_control</exec_depend>
   <exec_depend>ros2_controllers</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>


### PR DESCRIPTION
One-line addition to the package.xml definition for the demos so that rosdep knows to install the ros2_control package.
Fixes #74 

### To Test
Since the Docker/Dockerfile performs a clone of the repository@master, you can replace this line locally with my repository and branch and then build and test with Docker.

```sh
sed -i 's@git clone https://github.com/ros-simulation/gazebo_ros2_control@git clone --single-branch --branch demo-dependency-fix https://github.com/CSharpRon/gazebo_ros2_control@' Docker/Dockerfile 
cd Docker
docker build -t gazebo_ros2_control_demos:test .
docker run gazebo_ros2_control_demos:test
```