### PR TITLE
Join with the controller manager's executor thread on exit

### DIFF
--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -102,7 +102,7 @@ public:
   // Thread where the executor will sping
   std::thread thread_executor_spin_;
 
-  // Flag to stop the executor thread when gazebo exits
+  // Flag to stop the executor thread when this plugin is exiting
   bool stop_;
   
   // Controller manager
@@ -126,6 +126,7 @@ GazeboRosControlPlugin::GazeboRosControlPlugin()
 
 GazeboRosControlPlugin::~GazeboRosControlPlugin()
 {
+  // Stop controller manager thread
   impl_->stop_ = true;
   impl_->executor_->remove_node(impl_->controller_manager_);
   impl_->executor_->cancel();
@@ -133,7 +134,6 @@ GazeboRosControlPlugin::~GazeboRosControlPlugin()
   
   // Disconnect from gazebo events
   impl_->update_connection_.reset();
-
 }
 
 // Overloaded Gazebo entry point

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -104,7 +104,7 @@ public:
 
   // Flag to stop the executor thread when this plugin is exiting
   bool stop_;
-  
+
   // Controller manager
   std::shared_ptr<controller_manager::ControllerManager> controller_manager_;
 
@@ -116,7 +116,6 @@ public:
 
   // Last time the update method was called
   rclcpp::Time last_update_sim_time_ros_;
-  
 };
 
 GazeboRosControlPlugin::GazeboRosControlPlugin()
@@ -131,7 +130,7 @@ GazeboRosControlPlugin::~GazeboRosControlPlugin()
   impl_->executor_->remove_node(impl_->controller_manager_);
   impl_->executor_->cancel();
   impl_->thread_executor_spin_.join();
-  
+
   // Disconnect from gazebo events
   impl_->update_connection_.reset();
 }

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -315,7 +315,7 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
   impl_->stop_ = false;
   auto spin = [this]()
     {
-      while (rclcpp::ok() && ! impl_->stop_) {
+      while (rclcpp::ok() && !impl_->stop_) {
         impl_->executor_->spin_once();
       }
     };


### PR DESCRIPTION
This prevents a SIGABRT in gzserver when stopping gazebo due to the executor thread being aborted, which triggers a core dump.  This patch instead ensures a clean exit, since rclcpp::ok() returns true while gazebo is shutting down.

Note: I'm not sure why the controller manager's node must be removed from the executor, but otherwise the join() will remain blocked and prevent gzserver from stopping even with a SIGTERM.