### PR TITLE
Export interfaces created in init

### DIFF
--- a/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system.hpp
+++ b/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system.hpp
@@ -67,9 +67,14 @@ public:
     sdf::ElementPtr sdf) override;
 
 private:
+  void registerJoints(
+    const hardware_interface::HardwareInfo & hardware_info,
+    gazebo::physics::ModelPtr parent_model);
+
   void registerSensors(
     const hardware_interface::HardwareInfo & hardware_info,
     gazebo::physics::ModelPtr parent_model);
+
   /// \brief Private data class
   std::unique_ptr<GazeboSystemPrivate> dataPtr;
 };

--- a/gazebo_ros2_control/src/gazebo_system.cpp
+++ b/gazebo_ros2_control/src/gazebo_system.cpp
@@ -291,7 +291,8 @@ void GazeboSystem::registerSensors(
 
   this->dataPtr->imu_sensor_data_.resize(this->dataPtr->sim_imu_sensors_.size());
   this->dataPtr->ft_sensor_data_.resize(this->dataPtr->sim_ft_sensors_.size());
-  this->dataPtr->n_sensors_ = this->dataPtr->sim_imu_sensors_.size() + this->dataPtr->sim_ft_sensors_.size();
+  this->dataPtr->n_sensors_ = this->dataPtr->sim_imu_sensors_.size() +
+    this->dataPtr->sim_ft_sensors_.size();
 
   for (unsigned int i = 0; i < imu_components_.size(); i++) {
     const std::string & sensor_name = imu_components_[i].name;
@@ -315,9 +316,9 @@ void GazeboSystem::registerSensors(
 
       size_t data_index = interface_name_map.at(state_interface.name);
       this->dataPtr->state_interfaces_.emplace_back(
-          sensor_name,
-          state_interface.name,
-          &this->dataPtr->imu_sensor_data_[i][data_index]);
+        sensor_name,
+        state_interface.name,
+        &this->dataPtr->imu_sensor_data_[i][data_index]);
     }
   }
   for (unsigned int i = 0; i < ft_sensor_components_.size(); i++) {
@@ -338,9 +339,9 @@ void GazeboSystem::registerSensors(
 
       size_t data_index = interface_name_map.at(state_interface.name);
       this->dataPtr->state_interfaces_.emplace_back(
-          sensor_name,
-          state_interface.name,
-          &this->dataPtr->ft_sensor_data_[i][data_index]);
+        sensor_name,
+        state_interface.name,
+        &this->dataPtr->ft_sensor_data_[i][data_index]);
     }
   }
 }


### PR DESCRIPTION
Looking at the code, I noticed that the GazeboSystem creates state and command interfaces in 2 places:
1. [In the initSim method](https://github.com/ros-simulation/gazebo_ros2_control/blob/956e7706338fd4fd1a2ef733ad54740d07e9a67a/gazebo_ros2_control/src/gazebo_system.cpp#L143-L185). It creates only the handles for the interfaces defined in the URDF. 
2. [In export methods](https://github.com/ros-simulation/gazebo_ros2_control/blob/956e7706338fd4fd1a2ef733ad54740d07e9a67a/gazebo_ros2_control/src/gazebo_system.cpp#L199-L267). It creates handles for all interfaces (effort, velocity, position), regardless of whether they are defined in the URDF, and exports them to the Resource Manager.

This makes the handles created in 1. completely redundant (unless I'm missing something), as they are not used throughout the code.
I'm new to ros2_control but from what I understand the sole reason for creating the state and command interfaces is for them to be exported to the Resource Manager and not be cared about anymore.

In this PR, the export methods "move" interfaces created in initSim to the Resource Manager instead of creating new ones. This let's the user define in URDF what interfaces should a joint export. This also simplifies the code.
