### PR TITLE
Declare dependency of gazebo_hardware_plugins to urdf in CMakeLists.txt

### DIFF
--- a/gazebo_ros2_control/CMakeLists.txt
+++ b/gazebo_ros2_control/CMakeLists.txt
@@ -49,6 +49,7 @@ ament_target_dependencies(gazebo_hardware_plugins
   gazebo_dev
   hardware_interface
   rclcpp
+  urdf
 )
 
 ## Install

--- a/gazebo_ros2_control/CMakeLists.txt
+++ b/gazebo_ros2_control/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(gazebo_ros REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(urdf REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 
 # Default to C++14
@@ -37,7 +36,6 @@ ament_target_dependencies(${PROJECT_NAME}
   hardware_interface
   pluginlib
   rclcpp
-  urdf
   yaml_cpp_vendor
 )
 

--- a/gazebo_ros2_control/CMakeLists.txt
+++ b/gazebo_ros2_control/CMakeLists.txt
@@ -49,7 +49,6 @@ ament_target_dependencies(gazebo_hardware_plugins
   gazebo_dev
   hardware_interface
   rclcpp
-  urdf
 )
 
 ## Install

--- a/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system_interface.hpp
+++ b/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system_interface.hpp
@@ -28,8 +28,6 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-// URDF
-#include "urdf/model.h"
 
 namespace gazebo_ros2_control
 {

--- a/gazebo_ros2_control/package.xml
+++ b/gazebo_ros2_control/package.xml
@@ -26,7 +26,6 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
-  <depend>urdf</depend>
   <depend>yaml_cpp_vendor</depend>
 
   <test_depend>ament_lint_common</test_depend>

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -50,7 +50,6 @@
 #include "hardware_interface/component_parser.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 
-#include "urdf/model.h"
 #include "yaml-cpp/yaml.h"
 
 using namespace std::chrono_literals;

--- a/gazebo_ros2_control_demos/CMakeLists.txt
+++ b/gazebo_ros2_control_demos/CMakeLists.txt
@@ -23,7 +23,6 @@ find_package(std_msgs REQUIRED)
 install(DIRECTORY
   launch
   config
-  urdf
   DESTINATION share/${PROJECT_NAME}/
 )
 

--- a/gazebo_ros2_control_demos/CMakeLists.txt
+++ b/gazebo_ros2_control_demos/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(std_msgs REQUIRED)
 install(DIRECTORY
   launch
   config
+  urdf
   DESTINATION share/${PROJECT_NAME}/
 )
 


### PR DESCRIPTION
Since `gazebo_system_interface.hpp` includes urdf/model:

https://github.com/ros-simulation/gazebo_ros2_control/blob/698d01381423cea3232a78ab0ada7eb12cd6d40b/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system_interface.hpp#L32

I guess also the CMake target gazebo_hardware_plugins should depend on urdf.

At least that fixed my build on Ubuntu 18.04.