### PR TITLE
[Backport Foxy] Remove dependency of gazebo_hardware_plugins to urdf in CMakeLists.txt (#117)

### DIFF
--- a/gazebo_ros2_control/CMakeLists.txt
+++ b/gazebo_ros2_control/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(gazebo_ros REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(urdf REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 
 # Default to C++14
@@ -37,7 +36,6 @@ ament_target_dependencies(${PROJECT_NAME}
   hardware_interface
   pluginlib
   rclcpp
-  urdf
   yaml_cpp_vendor
 )
 

--- a/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system_interface.hpp
+++ b/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system_interface.hpp
@@ -30,8 +30,6 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-// URDF
-#include "urdf/model.h"
 
 namespace gazebo_ros2_control
 {

--- a/gazebo_ros2_control/package.xml
+++ b/gazebo_ros2_control/package.xml
@@ -26,7 +26,6 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
-  <depend>urdf</depend>
   <depend>yaml_cpp_vendor</depend>
 
   <test_depend>ament_lint_common</test_depend>

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -50,7 +50,6 @@
 #include "hardware_interface/component_parser.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 
-#include "urdf/model.h"
 #include "yaml-cpp/yaml.h"
 
 using namespace std::chrono_literals;


### PR DESCRIPTION
[Backport Foxy] Declare dependency of gazebo_hardware_plugins to urdf in CMakeLists.txt (#117)